### PR TITLE
fix(joinup): Map-merge and map-loop color variables to fix utilities - FRONT-3251

### DIFF
--- a/src/themes/joinup/src/scss/base/_variables.scss
+++ b/src/themes/joinup/src/scss/base/_variables.scss
@@ -18,14 +18,23 @@ $success: #18bf80;
 $warning: #eba843;
 $danger: #eb3434;
 
-$theme-colors: (
-  "brand": $brand,
-  "primary": $primary,
-  "secondary": $secondary,
-  "success": $success,
-  "warning": $warning,
-  "danger": $danger,
+// EU/EC color variables
+$ec-blue: #17458f;
+$eu-blue: #1b4ac3;
+$eu-light-blue: #f4f6fb;
+
+$theme-colors: map-merge(
+  $theme-colors,
+  (
+    "brand": $brand,
+    "primary": $primary,
+    "secondary": $secondary,
+    "success": $success,
+    "warning": $warning,
+    "danger": $danger,
+  )
 );
+$theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value");
 
 $gray-100: #fafbfc;
 $gray-200: #f5f6f7;
@@ -36,9 +45,6 @@ $gray-600: #6d7173;
 $gray-700: #555859;
 $gray-800: #3d3f40;
 $gray-900: #242626;
-
-$ec-blue: #1b4ac3;
-$eu-blue: #17458f;
 
 // Links
 $link-color: $brand;

--- a/src/themes/joinup/src/scss/base/_variables.scss
+++ b/src/themes/joinup/src/scss/base/_variables.scss
@@ -18,11 +18,6 @@ $success: #18bf80;
 $warning: #eba843;
 $danger: #eb3434;
 
-// EU/EC color variables
-$ec-blue: #17458f;
-$eu-blue: #1b4ac3;
-$eu-light-blue: #f4f6fb;
-
 $theme-colors: map-merge(
   $theme-colors,
   (
@@ -45,6 +40,11 @@ $gray-600: #6d7173;
 $gray-700: #555859;
 $gray-800: #3d3f40;
 $gray-900: #242626;
+
+// EU/EC color variables
+$ec-blue: #17458f;
+$eu-blue: #1b4ac3;
+$eu-light-blue: #f4f6fb;
 
 // Links
 $link-color: $brand;

--- a/src/themes/joinup/src/scss/oe-bcl-joinup.scss
+++ b/src/themes/joinup/src/scss/oe-bcl-joinup.scss
@@ -3,7 +3,7 @@
 @import "@openeuropa/bcl-bootstrap/scss/variables";
 
 // Override Bootstrap variables
-@import "base/variables";
+@import "@openeuropa/bcl-theme-joinup/src/scss/base/variables";
 
 @import "@openeuropa/bcl-bootstrap/scss/mixins";
 @import "@openeuropa/bcl-bootstrap/scss/utilities";


### PR DESCRIPTION
Bootstrap's update from 5.0 to 5.1 (updated in BCL v0.6.0) includes a change that requires the $theme-color overrides to be merged this way.

Run `yarn start joinup` and check the Compositions > Search page, the badges (that have the `bg-primary` class) must be in dark blue like the primary buttons. Before the fix, they appear in Bootstrap's default primary blue.