### PR TITLE
chore(joinup): Distributing roboto font files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/themes/joinup/storybook/.storybook/*.js
 src/themes/ucpkn/storybook/.storybook/*.js
 src/themes/*/templates
 src/themes/*/icons
+src/themes/*/fonts
 src/components/bcl-twig-templates/templates/
 vendor
 composer.lock

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "**/bootstrap",
       "**/bootstrap/**",
       "**/@openeuropa/bcl-twig-templates",
-      "**/@openeuropa/bcl-twig-templates/**"
+      "**/@openeuropa/bcl-twig-templates/**",
+      "**/@fontsource/**"
     ]
   },
   "jest": {

--- a/src/themes/joinup/package.json
+++ b/src/themes/joinup/package.json
@@ -6,6 +6,7 @@
   "description": "OE - BCL theme joinup",
   "scripts": {
     "build": "npm-run-all build:*",
+    "build:fonts": "copyfiles -f node_modules/@fontsource/roboto/{400,500,700}*.css fonts",
     "build:styles": "cross-env bcl-builder styles",
     "build:scripts": "cross-env bcl-builder scripts",
     "build:copy": "cross-env bcl-builder copy",
@@ -18,6 +19,7 @@
     "@openeuropa/bcl-builder": "^0.16.0",
     "@openeuropa/bcl-theme-default": "^0.16.0",
     "@openeuropa/bcl-twig-templates": "^0.16.0",
+    "@fontsource/roboto": "4.5.1",
     "copyfiles": "2.4.1",
     "cross-env": "7.0.3",
     "glob": "7.2.0",

--- a/src/themes/joinup/src/scss/base/_fonts.scss
+++ b/src/themes/joinup/src/scss/base/_fonts.scss
@@ -1,2 +1,6 @@
-// Temporarily get fonts from CDN
-@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap");
+@import "fonts/400.css";
+@import "fonts/500.css";
+@import "fonts/700.css";
+@import "fonts/400-italic.css";
+@import "fonts/500-italic.css";
+@import "fonts/700-italic.css";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,6 +1262,11 @@
   dependencies:
     "@figspec/components" "^1.0.0"
 
+"@fontsource/roboto@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.1.tgz#63f7b783f755d8f6727eb60198627e7e1be3ac20"
+  integrity sha512-3mhfL+eNPG/woMNqwD/OHaW5qMpeGEBsDwzmhFmjB1yUV+M+M9P0NhP/AyHvnGz3DrqkvZ7CPzNMa+UkVLeELg==
+
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"


### PR DESCRIPTION
In this PR:

- fetching the roboto npm package in the joinup theme
- copying the needed css file in the fonts folder
- importing from the freshly copied files

Please check what is really needed to be imported, based on that we would have to tweak the files copy