### PR TITLE
feat(accessibility): Select & Multiselect report - OEL-918

### DIFF
--- a/src/components/bcl-form/__snapshots__/form.test.js.snap
+++ b/src/components/bcl-form/__snapshots__/form.test.js.snap
@@ -277,11 +277,13 @@ exports[`OE - Form inline renders correctly 1`] = `
     >
       <label
         class="form-label visually-hidden"
+        for="inlineFormSelectPref"
       >
         Preference
       </label>
       <select
         class="form-select"
+        id="inlineFormSelectPref"
         required="true"
       >
         <option
@@ -382,6 +384,7 @@ exports[`OE - Form renders correctly when disabled 1`] = `
       >
         <select
           class="form-select"
+          id="disabledSelect"
         >
           <option
             value="1"

--- a/src/components/bcl-select/__snapshots__/select.test.js.snap
+++ b/src/components/bcl-select/__snapshots__/select.test.js.snap
@@ -61,7 +61,14 @@ exports[`OE - select renders correctly 1`] = `
 
 exports[`OE - select renders correctly as a multiple choice select 1`] = `
 <jest>
+  <label
+    class="form-label"
+    for="multiselect-1"
+  >
+    A multiselect form element
+  </label>
   <select
+    id="multiselect-1"
     multiple="true"
     required="true"
   >

--- a/src/components/bcl-select/__snapshots__/select.test.js.snap
+++ b/src/components/bcl-select/__snapshots__/select.test.js.snap
@@ -4,11 +4,13 @@ exports[`OE - select renders correctly 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select"
+    id="select-1"
     required="true"
   >
     <option
@@ -132,12 +134,14 @@ exports[`OE - select renders correctly when disabled 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select"
     disabled="true"
+    id="select-1"
     required="true"
   >
     <option
@@ -190,11 +194,13 @@ exports[`OE - select renders correctly when invalid 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select is-invalid"
+    id="select-1"
     required="true"
   >
     <option
@@ -247,11 +253,13 @@ exports[`OE - select renders correctly when multiple 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select"
+    id="select-1"
     multiple="true"
     required="true"
   >
@@ -305,11 +313,13 @@ exports[`OE - select renders correctly when readonly 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select"
+    id="select-1"
     required="true"
   >
     <option
@@ -362,11 +372,13 @@ exports[`OE - select renders correctly when required 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select"
+    id="select-1"
     required="true"
   >
     <option
@@ -419,11 +431,13 @@ exports[`OE - select renders correctly when valid 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select form element
   </label>
   <select
     class="form-select is-valid"
+    id="select-1"
     required="true"
   >
     <option
@@ -476,11 +490,13 @@ exports[`OE - select renders correctly with a label 1`] = `
 <jest>
   <label
     class="form-label"
+    for="select-1"
   >
     A select label
   </label>
   <select
     class="form-select"
+    id="select-1"
     required="true"
   >
     <option
@@ -533,11 +549,13 @@ exports[`OE - select renders correctly with an hidden label 1`] = `
 <jest>
   <label
     class="form-label visually-hidden"
+    for="select-1"
   >
     A select label
   </label>
   <select
     class="form-select"
+    id="select-1"
     required="true"
   >
     <option

--- a/src/components/bcl-select/select.html.twig
+++ b/src/components/bcl-select/select.html.twig
@@ -2,6 +2,7 @@
 
 {#
   Parameters:
+  - "id" (string) (default: '')
   - "label" (string) (default: '')
   - "hidden_label" (boolean) (default: false)
   - "helper_text" (string) (default: '')
@@ -18,6 +19,7 @@
 #}
 
 {% set _classes = ['form-select'] %}
+{% set _id = id|default('') %}
 {% set _disabled = disabled|default(false) %}
 {% set _options = options|default([]) %}
 {% set _aria_label = aria_label|default('') %}
@@ -53,6 +55,10 @@
 
 {% if _aria_label is not empty %}
   {% set attributes = attributes.setAttribute('aria-label', _aria_label) %}
+{% endif %}
+
+{% if _id is not empty %}
+  {% set attributes = attributes.setAttribute('id', _id) %}
 {% endif %}
 
 {% if _disabled %}

--- a/src/data/select/data.js
+++ b/src/data/select/data.js
@@ -1,4 +1,5 @@
 module.exports = {
+  id: "select-1",
   label: "A select form element",
   required: true,
   helper_text: "Helper text for the select element",

--- a/src/data/select/dataMultiselect.js
+++ b/src/data/select/dataMultiselect.js
@@ -1,10 +1,12 @@
 const drupalAttribute = require("drupal-attribute");
 
 module.exports = {
+  id: "multiselect-1",
   multiple: true,
   clean_class: true,
   required: true,
   size: "md",
+  label: "A multiselect form element",
   helper_text: "Helper text for the select element",
   helper_text_id: "helperText",
   invalid_feedback: "Invalid feedback example",


### PR DESCRIPTION
The Incomplete rule is because of the arrow bg image on the right of the select. I think it should not be taken into consideration.

Multiselect
The only violation remained is:
Scrollable region must have keyboard access

But i think it's not necessary. that violation is regarding the select that we hide it using opacity 0 and the rule apply to it even if it's hidden (should have been done with display:none; to pass but this approach was done because of the focus state of multiselect #78 ) and it also checks the list of the multiselect that can not be controlled using the tab (which this is checked in the rule) but it can be controlled using the arrows so i think it is good enough.