### PR TITLE
feat(placeholder): Reset em placeholder styles - OEL-1184

### DIFF
--- a/src/components/bcl-alert/__snapshots__/alert.test.js.snap
+++ b/src/components/bcl-alert/__snapshots__/alert.test.js.snap
@@ -21,7 +21,12 @@ exports[`OE - Alert danger renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -54,7 +59,12 @@ exports[`OE - Alert dark renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -87,7 +97,12 @@ exports[`OE - Alert info renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -120,7 +135,12 @@ exports[`OE - Alert light renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -153,7 +173,12 @@ exports[`OE - Alert primary renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -186,7 +211,12 @@ exports[`OE - Alert renders correctly without animation for the close button 1`]
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -219,7 +249,12 @@ exports[`OE - Alert renders correctly without close button 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
   </div>
 </jest>
@@ -246,7 +281,12 @@ exports[`OE - Alert secondary renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -279,7 +319,12 @@ exports[`OE - Alert success renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"
@@ -312,7 +357,12 @@ exports[`OE - Alert warning renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      A simple alert. check it out!
+      <em
+        class="placeholder"
+      >
+        A simple alert
+      </em>
+      . Check it out!
     </div>
     <button
       aria-label="Close"

--- a/src/components/bcl-alert/__snapshots__/alert.test.js.snap
+++ b/src/components/bcl-alert/__snapshots__/alert.test.js.snap
@@ -21,12 +21,7 @@ exports[`OE - Alert danger renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -59,12 +54,7 @@ exports[`OE - Alert dark renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -97,12 +87,7 @@ exports[`OE - Alert info renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -135,12 +120,7 @@ exports[`OE - Alert light renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -173,12 +153,7 @@ exports[`OE - Alert primary renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -211,12 +186,7 @@ exports[`OE - Alert renders correctly without animation for the close button 1`]
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -249,12 +219,7 @@ exports[`OE - Alert renders correctly without close button 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
   </div>
 </jest>
@@ -281,12 +246,7 @@ exports[`OE - Alert secondary renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -319,12 +279,7 @@ exports[`OE - Alert success renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"
@@ -357,12 +312,7 @@ exports[`OE - Alert warning renders correctly 1`] = `
       >
         Alert heading
       </h4>
-      <em
-        class="placeholder"
-      >
-        A simple alert
-      </em>
-      . Check it out!
+      A simple alert. Check it out!
     </div>
     <button
       aria-label="Close"

--- a/src/data/alert/data.js
+++ b/src/data/alert/data.js
@@ -1,5 +1,5 @@
 module.exports = {
-  message: " <em class='placeholder'>A simple alert</em>. Check it out!",
+  message: "A simple alert. Check it out!",
   heading: "Alert heading",
   icon_path: "/icons.svg",
 };

--- a/src/data/alert/data.js
+++ b/src/data/alert/data.js
@@ -1,5 +1,5 @@
 module.exports = {
-  message: "A simple alert. check it out!",
+  message: " <em class='placeholder'>A simple alert</em>. Check it out!",
   heading: "Alert heading",
   icon_path: "/icons.svg",
 };

--- a/src/themes/default/src/scss/_reset.scss
+++ b/src/themes/default/src/scss/_reset.scss
@@ -3,3 +3,12 @@ body {
   // needed for full-width banner
   overflow-x: hidden;
 }
+
+em.placeholder {
+  background-color: transparent;
+  cursor: auto;
+  min-height: 0;
+  vertical-align: baseline;
+  opacity: 1;
+  display: inline;
+}


### PR DESCRIPTION
https://www.drupal.org/project/drupal/issues/3233533
https://www.drupal.org/project/bootstrap_barrio/issues/3228330
https://www.drupal.org/project/vartheme_bs5/issues/3246827

I found better to reset the em.placeholder values than to remove a whole component. As i saw on multiple topics on drupal this placeholder class is added only on the em tag.