### PR TITLE
Fix(bcl-icon): Deprecated XLink URL reference attributes

### DIFF
--- a/src/components/bcl-icon/icon.html.twig
+++ b/src/components/bcl-icon/icon.html.twig
@@ -28,7 +28,7 @@
 <svg
   {{ attributes }}
 >
-  <use xlink:href="{{ _path ~ "#" ~ _name }}"/>
+  <use href="{{ _path ~ "#" ~ _name }} xlink:href="{{ _path ~ "#" ~ _name }}"/>
 </svg>
 
 {% endspaceless %}


### PR DESCRIPTION
References: 
- https://www.w3.org/TR/SVG/linking.html#XLinkRefAttrs 
- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href