### PR TITLE
feat(file): Adding target=_blank to download links - OEL-1570

### DIFF
--- a/src/compositions/bcl-event/__snapshots__/event.test.js.snap
+++ b/src/compositions/bcl-event/__snapshots__/event.test.js.snap
@@ -2680,7 +2680,8 @@ exports[`OE - event page renders correctly 1`] = `
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                     download="true"
-                    href="#"
+                    href="/example.html"
+                    target="_blank"
                   >
                     Download
                     <svg
@@ -2736,7 +2737,8 @@ exports[`OE - event page renders correctly 1`] = `
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                     download="true"
-                    href="#"
+                    href="/example.html"
+                    target="_blank"
                   >
                     Download
                     <svg

--- a/src/compositions/bcl-event/__snapshots__/event.test.js.snap
+++ b/src/compositions/bcl-event/__snapshots__/event.test.js.snap
@@ -2679,7 +2679,7 @@ exports[`OE - event page renders correctly 1`] = `
                   </div>
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                    download="/example.html"
+                    download="true"
                     href="#"
                   >
                     Download
@@ -2735,7 +2735,7 @@ exports[`OE - event page renders correctly 1`] = `
                   </div>
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                    download="/example.html"
+                    download="true"
                     href="#"
                   >
                     Download

--- a/src/compositions/bcl-event/__snapshots__/event.test.js.snap
+++ b/src/compositions/bcl-event/__snapshots__/event.test.js.snap
@@ -2640,7 +2640,7 @@ exports[`OE - event page renders correctly 1`] = `
             Related documents
           </h2>
           <div
-            class="mb-3-5 border rounded"
+            class="mb-3-5 bcl-file border rounded"
           >
             <div
               class="px-3-5 py-3"
@@ -2697,7 +2697,7 @@ exports[`OE - event page renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="mb-3-5 border rounded"
+            class="mb-3-5 bcl-file border rounded"
           >
             <div
               class="px-3-5 py-3"

--- a/src/compositions/bcl-event/event.story.js
+++ b/src/compositions/bcl-event/event.story.js
@@ -29,9 +29,11 @@ import event from "@openeuropa/bcl-event/event.html.twig";
 const header =
   layout[`header_${process.env.STORYBOOK_THEME}`] || layout.headerSimple;
 
-delete file.translation;
-file.attributes = new drupalAttribute().addClass(["mb-3-5"]);
-const files = [file, file];
+let simpleFile = { ...file };
+
+delete simpleFile.translation;
+simpleFile.attributes = new drupalAttribute().addClass(["mb-3-5"]);
+const files = [simpleFile, simpleFile];
 
 const baseData = {
   content_type: "event",

--- a/src/compositions/bcl-file/__snapshots__/file.test.js.snap
+++ b/src/compositions/bcl-file/__snapshots__/file.test.js.snap
@@ -99,7 +99,7 @@ exports[`OE - File Card renders correctly 1`] = `
           </div>
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-            download="/example.html"
+            download="true"
             href="#"
           >
             Download
@@ -416,7 +416,7 @@ exports[`OE - File Card renders correctly with title 1`] = `
           </div>
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-            download="/example.html"
+            download="true"
             href="#"
           >
             Download
@@ -671,7 +671,7 @@ exports[`OE - File renders correctly 1`] = `
           </div>
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-            download="/example.html"
+            download="true"
             href="#"
           >
             Download
@@ -902,7 +902,7 @@ exports[`OE - File renders correctly with title 1`] = `
           </div>
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-            download="/example.html"
+            download="true"
             href="#"
           >
             Download

--- a/src/compositions/bcl-file/__snapshots__/file.test.js.snap
+++ b/src/compositions/bcl-file/__snapshots__/file.test.js.snap
@@ -72,7 +72,7 @@ exports[`OE - File Card renders correctly 1`] = `
     </div>
   </article>
   <div
-    class="border rounded-bottom"
+    class="bcl-file border rounded-bottom"
   >
     <div
       class="px-3-5 py-3"
@@ -393,7 +393,7 @@ exports[`OE - File Card renders correctly with title 1`] = `
     </div>
   </article>
   <div
-    class="border rounded-bottom"
+    class="bcl-file border rounded-bottom"
   >
     <div
       class="px-3-5 py-3"
@@ -640,7 +640,7 @@ exports[`OE - File Card renders correctly with title 1`] = `
 exports[`OE - File renders correctly 1`] = `
 <jest>
   <div
-    class="border rounded"
+    class="bcl-file border rounded"
   >
     <div
       class="px-3-5 py-3"
@@ -875,7 +875,7 @@ exports[`OE - File renders correctly with title 1`] = `
     File test title
   </h6>
   <div
-    class="border rounded"
+    class="bcl-file border rounded"
   >
     <div
       class="px-3-5 py-3"

--- a/src/compositions/bcl-file/__snapshots__/file.test.js.snap
+++ b/src/compositions/bcl-file/__snapshots__/file.test.js.snap
@@ -28,7 +28,7 @@ exports[`OE - File Card renders correctly 1`] = `
           >
             <a
               class="standalone"
-              href="#"
+              href="/example.html"
             >
               Article title
             </a>
@@ -100,7 +100,8 @@ exports[`OE - File Card renders correctly 1`] = `
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
             download="true"
-            href="#"
+            href="/example.html"
+            target="_blank"
           >
             Download
             <svg
@@ -177,8 +178,9 @@ exports[`OE - File Card renders correctly 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -227,8 +229,9 @@ exports[`OE - File Card renders correctly 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -277,8 +280,9 @@ exports[`OE - File Card renders correctly 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -345,7 +349,7 @@ exports[`OE - File Card renders correctly with title 1`] = `
           >
             <a
               class="standalone"
-              href="#"
+              href="/example.html"
             >
               Article title
             </a>
@@ -417,7 +421,8 @@ exports[`OE - File Card renders correctly with title 1`] = `
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
             download="true"
-            href="#"
+            href="/example.html"
+            target="_blank"
           >
             Download
             <svg
@@ -494,8 +499,9 @@ exports[`OE - File Card renders correctly with title 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -544,8 +550,9 @@ exports[`OE - File Card renders correctly with title 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -594,8 +601,9 @@ exports[`OE - File Card renders correctly with title 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -672,7 +680,8 @@ exports[`OE - File renders correctly 1`] = `
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
             download="true"
-            href="#"
+            href="/example.html"
+            target="_blank"
           >
             Download
             <svg
@@ -739,8 +748,9 @@ exports[`OE - File renders correctly 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="http://www.africau.edu/images/default/sample.pdf"
+                target="_blank"
               >
                 Download
                 <svg
@@ -779,8 +789,9 @@ exports[`OE - File renders correctly 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -819,8 +830,9 @@ exports[`OE - File renders correctly 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -903,7 +915,8 @@ exports[`OE - File renders correctly with title 1`] = `
           <a
             class="standalone align-self-center d-inline-block mt-1 mt-md-0"
             download="true"
-            href="#"
+            href="/example.html"
+            target="_blank"
           >
             Download
             <svg
@@ -970,8 +983,9 @@ exports[`OE - File renders correctly with title 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="http://www.africau.edu/images/default/sample.pdf"
+                target="_blank"
               >
                 Download
                 <svg
@@ -1010,8 +1024,9 @@ exports[`OE - File renders correctly with title 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg
@@ -1050,8 +1065,9 @@ exports[`OE - File renders correctly with title 1`] = `
             >
               <a
                 class="d-block standalone mt-1"
-                download="/example.html"
-                href="#"
+                download="true"
+                href="/example.html"
+                target="_blank"
               >
                 Download
                 <svg

--- a/src/compositions/bcl-file/data/data--card.js
+++ b/src/compositions/bcl-file/data/data--card.js
@@ -1,5 +1,5 @@
 module.exports = {
-  item_title: "<a href='#' class='standalone'>Article title</a>",
+  item_title: "<a href='/example.html' class='standalone'>Article title</a>",
   text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ut ex tristique, dignissim sem ac, bibendum est. Sed vehicula lorem non nunc tincidunt hendrerit. Nunc tristique ante et fringilla fermentum.",
   content:
     "<span class='text-muted d-block d-md-inline-block me-3 mb-3 mb-md-0 text-nowrap'>Article</span><span class='text-muted d-block d-md-inline-block me-3 mb-3 mb-md-0 text-nowrap'>Brussels, Belgium</span><span class='text-muted d-block d-md-inline-block me-3 text-nowrap'>17 October 2019</span>",
@@ -24,7 +24,7 @@ module.exports = {
   meta: "(16.2 MB - PDF)",
   download: {
     label: "Download",
-    url: "/example.html",
+    path: "/example.html",
   },
   variant: "card",
   translation: {
@@ -47,7 +47,7 @@ module.exports = {
         meta: "(16.2 MB - PDF)",
         download: {
           label: "Download",
-          url: "/example.html",
+          path: "/example.html",
         },
       },
       {
@@ -58,7 +58,7 @@ module.exports = {
         meta: "(16.2 MB - PDF)",
         download: {
           label: "Download",
-          url: "/example.html",
+          path: "/example.html",
         },
       },
       {
@@ -69,7 +69,7 @@ module.exports = {
         meta: "(16.2 MB - PDF)",
         download: {
           label: "Download",
-          url: "/example.html",
+          path: "/example.html",
         },
       },
       {

--- a/src/compositions/bcl-file/data/data.js
+++ b/src/compositions/bcl-file/data/data.js
@@ -5,7 +5,7 @@ module.exports = {
   icon_path: "/icons.svg",
   download: {
     label: "Download",
-    url: "/example.html",
+    path: "/example.html",
   },
   icon: {
     name: "file-pdf-fill",
@@ -28,7 +28,7 @@ module.exports = {
         meta: "(16.2 MB - PDF)",
         download: {
           label: "Download",
-          url: "/example.html",
+          path: "http://www.africau.edu/images/default/sample.pdf",
         },
       },
       {
@@ -36,7 +36,7 @@ module.exports = {
         meta: "(16.2 MB - PDF)",
         download: {
           label: "Download",
-          url: "/example.html",
+          path: "/example.html",
         },
       },
       {
@@ -44,7 +44,7 @@ module.exports = {
         meta: "(16.2 MB - PDF)",
         download: {
           label: "Download",
-          url: "/example.html",
+          path: "/example.html",
         },
       },
       {

--- a/src/compositions/bcl-file/file.html.twig
+++ b/src/compositions/bcl-file/file.html.twig
@@ -53,16 +53,18 @@
 {% set _translation = translation|default({}) %}
 {% set _icon_path = icon_path|default({}) %}
 
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+{% set attributes = attributes.addClass(['bcl-file']) %}
+
 {% set _container_classes = 'w-100 d-md-flex' %}
 {% if _icon is not empty %}
   {% set _container_classes = _container_classes ~ ' ms-2-5' %}
   {% set _icon = _icon|merge({
     attributes: create_attribute().addClass(['mt-1', 'icon--file'])
   }) %}
-{% endif %}
-
-{% if attributes is empty %}
-  {% set attributes = create_attribute() %}
 {% endif %}
 
 {% if _title is not empty %}

--- a/src/compositions/bcl-file/file.html.twig
+++ b/src/compositions/bcl-file/file.html.twig
@@ -138,7 +138,7 @@
             path: _icon_path,
           },
           attributes: create_attribute()
-                      .setAttribute('download', _download.url)
+                      .setAttribute('download', true)
                       .addClass(['standalone', 'align-self-center', 'd-inline-block', 'mt-1', 'mt-md-0'])
         }) %}
         {% include '@oe-bcl/bcl-link/link.html.twig' with _download only %}

--- a/src/compositions/bcl-file/file.html.twig
+++ b/src/compositions/bcl-file/file.html.twig
@@ -139,6 +139,7 @@
           },
           attributes: create_attribute()
                       .setAttribute('download', true)
+                      .setAttribute('target', '_blank')
                       .addClass(['standalone', 'align-self-center', 'd-inline-block', 'mt-1', 'mt-md-0'])
         }) %}
         {% include '@oe-bcl/bcl-link/link.html.twig' with _download only %}
@@ -197,7 +198,8 @@
                 path: _icon_path,
               },
               attributes: create_attribute()
-                          .setAttribute("download", _item.download.url)
+                          .setAttribute('download', true)
+                          .setAttribute('target', '_blank')
                           .addClass(['d-block', 'standalone', 'mt-1'])
             }) only %}
             </div>

--- a/src/compositions/bcl-page/__snapshots__/page.test.js.snap
+++ b/src/compositions/bcl-page/__snapshots__/page.test.js.snap
@@ -890,7 +890,8 @@ exports[`OE - Page Page renders correctly 1`] = `
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                     download="true"
-                    href="#"
+                    href="/example.html"
+                    target="_blank"
                   >
                     Download
                     <svg
@@ -957,8 +958,9 @@ exports[`OE - Page Page renders correctly 1`] = `
                     >
                       <a
                         class="d-block standalone mt-1"
-                        download="/example.html"
-                        href="#"
+                        download="true"
+                        href="http://www.africau.edu/images/default/sample.pdf"
+                        target="_blank"
                       >
                         Download
                         <svg
@@ -997,8 +999,9 @@ exports[`OE - Page Page renders correctly 1`] = `
                     >
                       <a
                         class="d-block standalone mt-1"
-                        download="/example.html"
-                        href="#"
+                        download="true"
+                        href="/example.html"
+                        target="_blank"
                       >
                         Download
                         <svg
@@ -1037,8 +1040,9 @@ exports[`OE - Page Page renders correctly 1`] = `
                     >
                       <a
                         class="d-block standalone mt-1"
-                        download="/example.html"
-                        href="#"
+                        download="true"
+                        href="/example.html"
+                        target="_blank"
                       >
                         Download
                         <svg
@@ -1111,7 +1115,8 @@ exports[`OE - Page Page renders correctly 1`] = `
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                     download="true"
-                    href="#"
+                    href="/example.html"
+                    target="_blank"
                   >
                     Download
                     <svg
@@ -1178,8 +1183,9 @@ exports[`OE - Page Page renders correctly 1`] = `
                     >
                       <a
                         class="d-block standalone mt-1"
-                        download="/example.html"
-                        href="#"
+                        download="true"
+                        href="http://www.africau.edu/images/default/sample.pdf"
+                        target="_blank"
                       >
                         Download
                         <svg
@@ -1218,8 +1224,9 @@ exports[`OE - Page Page renders correctly 1`] = `
                     >
                       <a
                         class="d-block standalone mt-1"
-                        download="/example.html"
-                        href="#"
+                        download="true"
+                        href="/example.html"
+                        target="_blank"
                       >
                         Download
                         <svg
@@ -1258,8 +1265,9 @@ exports[`OE - Page Page renders correctly 1`] = `
                     >
                       <a
                         class="d-block standalone mt-1"
-                        download="/example.html"
-                        href="#"
+                        download="true"
+                        href="/example.html"
+                        target="_blank"
                       >
                         Download
                         <svg

--- a/src/compositions/bcl-page/__snapshots__/page.test.js.snap
+++ b/src/compositions/bcl-page/__snapshots__/page.test.js.snap
@@ -850,7 +850,7 @@ exports[`OE - Page Page renders correctly 1`] = `
   
           </p>
           <div
-            class="border rounded"
+            class="bcl-file border rounded"
           >
             <div
               class="px-3-5 py-3"
@@ -1075,7 +1075,7 @@ exports[`OE - Page Page renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="border rounded"
+            class="bcl-file border rounded"
           >
             <div
               class="px-3-5 py-3"

--- a/src/compositions/bcl-page/__snapshots__/page.test.js.snap
+++ b/src/compositions/bcl-page/__snapshots__/page.test.js.snap
@@ -889,7 +889,7 @@ exports[`OE - Page Page renders correctly 1`] = `
                   </div>
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                    download="/example.html"
+                    download="true"
                     href="#"
                   >
                     Download
@@ -1110,7 +1110,7 @@ exports[`OE - Page Page renders correctly 1`] = `
                   </div>
                   <a
                     class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                    download="/example.html"
+                    download="true"
                     href="#"
                   >
                     Download

--- a/src/compositions/bcl-person/__snapshots__/person.test.js.snap
+++ b/src/compositions/bcl-person/__snapshots__/person.test.js.snap
@@ -769,7 +769,7 @@ exports[`OE - Person details renders correctly 1`] = `
             class="mb-4-5"
           >
             <div
-              class="mb-3 border rounded"
+              class="mb-3 bcl-file border rounded"
             >
               <div
                 class="px-3-5 py-3"
@@ -826,7 +826,7 @@ exports[`OE - Person details renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="mb-3 border rounded"
+              class="mb-3 bcl-file border rounded"
             >
               <div
                 class="px-3-5 py-3"

--- a/src/compositions/bcl-person/__snapshots__/person.test.js.snap
+++ b/src/compositions/bcl-person/__snapshots__/person.test.js.snap
@@ -810,6 +810,7 @@ exports[`OE - Person details renders correctly 1`] = `
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                       download="true"
                       href="#"
+                      target="_blank"
                     >
                       Download
                       <svg
@@ -866,6 +867,7 @@ exports[`OE - Person details renders correctly 1`] = `
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                       download="true"
                       href="#"
+                      target="_blank"
                     >
                       Download
                       <svg

--- a/src/compositions/bcl-person/__snapshots__/person.test.js.snap
+++ b/src/compositions/bcl-person/__snapshots__/person.test.js.snap
@@ -808,7 +808,7 @@ exports[`OE - Person details renders correctly 1`] = `
                     </div>
                     <a
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                      download="/example.html"
+                      download="true"
                       href="#"
                     >
                       Download
@@ -864,7 +864,7 @@ exports[`OE - Person details renders correctly 1`] = `
                     </div>
                     <a
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                      download="/example.html"
+                      download="true"
                       href="#"
                     >
                       Download

--- a/src/compositions/bcl-publication/__snapshots__/publication.test.js.snap
+++ b/src/compositions/bcl-publication/__snapshots__/publication.test.js.snap
@@ -859,7 +859,7 @@ exports[`OE - Publication details (multiple authors) renders correctly 1`] = `
                     </div>
                     <a
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                      download="/example.html"
+                      download="true"
                       href="#"
                     >
                       Download
@@ -2553,7 +2553,7 @@ exports[`OE - Publication details renders correctly 1`] = `
                     </div>
                     <a
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
-                      download="/example.html"
+                      download="true"
                       href="#"
                     >
                       Download

--- a/src/compositions/bcl-publication/__snapshots__/publication.test.js.snap
+++ b/src/compositions/bcl-publication/__snapshots__/publication.test.js.snap
@@ -820,7 +820,7 @@ exports[`OE - Publication details (multiple authors) renders correctly 1`] = `
               File download
             </h2>
             <div
-              class="border rounded"
+              class="bcl-file border rounded"
             >
               <div
                 class="px-3-5 py-3"
@@ -2518,7 +2518,7 @@ exports[`OE - Publication details renders correctly 1`] = `
               File download
             </h2>
             <div
-              class="border rounded"
+              class="bcl-file border rounded"
             >
               <div
                 class="px-3-5 py-3"

--- a/src/compositions/bcl-publication/__snapshots__/publication.test.js.snap
+++ b/src/compositions/bcl-publication/__snapshots__/publication.test.js.snap
@@ -861,6 +861,7 @@ exports[`OE - Publication details (multiple authors) renders correctly 1`] = `
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                       download="true"
                       href="#"
+                      target="_blank"
                     >
                       Download
                       <svg
@@ -937,8 +938,9 @@ exports[`OE - Publication details (multiple authors) renders correctly 1`] = `
                       >
                         <a
                           class="d-block standalone mt-1"
-                          download="/example.html"
+                          download="true"
                           href="#"
+                          target="_blank"
                         >
                           Download
                           <svg
@@ -987,8 +989,9 @@ exports[`OE - Publication details (multiple authors) renders correctly 1`] = `
                       >
                         <a
                           class="d-block standalone mt-1"
-                          download="/example.html"
+                          download="true"
                           href="#"
+                          target="_blank"
                         >
                           Download
                           <svg
@@ -1037,8 +1040,9 @@ exports[`OE - Publication details (multiple authors) renders correctly 1`] = `
                       >
                         <a
                           class="d-block standalone mt-1"
-                          download="/example.html"
+                          download="true"
                           href="#"
+                          target="_blank"
                         >
                           Download
                           <svg
@@ -2555,6 +2559,7 @@ exports[`OE - Publication details renders correctly 1`] = `
                       class="standalone align-self-center d-inline-block mt-1 mt-md-0"
                       download="true"
                       href="#"
+                      target="_blank"
                     >
                       Download
                       <svg
@@ -2631,8 +2636,9 @@ exports[`OE - Publication details renders correctly 1`] = `
                       >
                         <a
                           class="d-block standalone mt-1"
-                          download="/example.html"
+                          download="true"
                           href="#"
+                          target="_blank"
                         >
                           Download
                           <svg
@@ -2681,8 +2687,9 @@ exports[`OE - Publication details renders correctly 1`] = `
                       >
                         <a
                           class="d-block standalone mt-1"
-                          download="/example.html"
+                          download="true"
                           href="#"
+                          target="_blank"
                         >
                           Download
                           <svg
@@ -2731,8 +2738,9 @@ exports[`OE - Publication details renders correctly 1`] = `
                       >
                         <a
                           class="d-block standalone mt-1"
-                          download="/example.html"
+                          download="true"
                           href="#"
+                          target="_blank"
                         >
                           Download
                           <svg


### PR DESCRIPTION
Short explanation:
the download attribute works only with same origin links, this means that if an external file is linked this would normally open in the same tab if no target is specified.
To improve the user experience, we are adding target="_blank" so that if the file is external it will be opened (not downloaded) in a new tab.

There were issues with the specs which have been fixed, hopefully, mind the fact that in our demo the attribute is rendered as download="true" which makes appear the file to be downloaded as true.html, in drupal the attribute would be properly rendered as a boolean and the file name would not be touched.