### PR TITLE
[do not merge] OEL-1500: Vertical margins proof-of-concept.

### DIFF
--- a/src/components/bcl-section/section.html.twig
+++ b/src/components/bcl-section/section.html.twig
@@ -1,0 +1,41 @@
+{% spaceless %}
+
+  {# Parameters:
+  - title (string) (default: '')
+  - content (string)
+  - id (string) (default: '')
+  #}
+
+  {% set _title = title|default('') %}
+  {% set _content = content %}
+  {% set _id = id|default('') %}
+
+  {% if attributes is empty %}
+    {% set attributes = create_attribute() %}
+  {%  endif %}
+
+  {% if attributes.class is empty %}
+    {% set attributes = attributes.addClass(['mb-5']) %}
+  {% endif %}
+
+  {% if _id is not empty %}
+    {# Put the id directly on the <section> instead of the title, should work fine. #}
+    {% set attributes = attributes.setAttribute('id', _id) %}
+  {% endif %}
+
+  {% set _content_rendered %}{{ _content }}{% endset %}
+
+  {% if _content_rendered|trim is not empty %}
+    <section{{ attributes }}>
+      {% if _title is not empty %}
+        {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+          title: _title,
+          title_tag: 'h2',
+          attributes: create_attribute().addClass(['mb-4'])
+        } only %}
+      {% endif %}
+      {{ _content_rendered }}
+    </section>
+  {% endif %}
+
+{% endspaceless %}

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -64,7 +64,7 @@
   {% include '@oe-bcl/bcl-header/header.html.twig' with header only %}
 {% endif %}
 
-<main {{ attributes }}>
+<main {{ attributes.addClass('mb-5') }}>
   {% if messages is defined and messages is not empty %}
     {% block messages_area %}
       <div class="container">

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -52,32 +52,6 @@
   {% endblock %}
 {% endset %}
 
-{% if _with_sidebar %}
-  {% set _col_classes = {
-    left: [
-      'col-12',
-      'bcl-sidebar',
-    ],
-    right: [
-      'col-12',
-    ],
-  } %}
-
-  {% if _sidebar_size == 'normal' %}
-    {% set _col_classes = _col_classes|merge({
-      left: _col_classes.left|merge(['col-lg-3']),
-      right: _col_classes.right|merge(['col-lg-9', 'col-xxl-8']),
-    }) %}
-  {% endif %}
-
-  {% if _sidebar_size == 'large' %}
-    {% set _col_classes = _col_classes|merge({
-      left: _col_classes.left|merge(['col-lg-4']),
-      right: _col_classes.right|merge(['col-lg-8']),
-    }) %}
-  {% endif %}
-{% endif %}
-
 {% if _content_type is not empty %}
   {% set _classes = _classes|merge(['bcl-' ~ _content_type]) %}
 {% endif %}
@@ -113,13 +87,15 @@
   <div class="container mt-md-4-75 mt-4">
     {% block content_row %}{% endblock %}
     {% if _with_sidebar %}
+      {% set _sidebar_rendered %}{% block sidebar %}{% endblock %}{% endset %}
       <div class="row">
-        <div class="{{ _col_classes.left|join(' ') }}">
-          {% block sidebar %}{% endblock %}
-        </div>
-        <div class="{{ _col_classes.right|join(' ') }}">
-          {{ _content_rendered }}
-        </div>
+        {% if _sidebar_size == 'large' %}
+          <div class="bcl-sidebar col-12 col-lg-4">{{ _sidebar_rendered }}</div>
+          <div class="col-12 col-lg-8">{{ _content_rendered }}</div>
+        {% else %}
+          <div class="bcl-sidebar col-12 col-lg-3">{{ _sidebar_rendered }}</div>
+          <div class="col-12 col-lg-9 col-xxl-8">{{ _content_rendered }}</div>
+        {% endif %}
       </div>
     {% elseif _landing %}
       {# No wrappers needed. #}

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -90,11 +90,11 @@
       {% set _sidebar_rendered %}{% block sidebar %}{% endblock %}{% endset %}
       <div class="row">
         {% if _sidebar_size == 'large' %}
-          <div class="bcl-sidebar col-12 col-lg-4">{{ _sidebar_rendered }}</div>
-          <div class="col-12 col-lg-8">{{ _content_rendered }}</div>
+          <div class="bcl-sidebar col-lg-4">{{ _sidebar_rendered }}</div>
+          <div class="col-lg-8">{{ _content_rendered }}</div>
         {% else %}
-          <div class="bcl-sidebar col-12 col-lg-3">{{ _sidebar_rendered }}</div>
-          <div class="col-12 col-lg-9 col-xxl-8">{{ _content_rendered }}</div>
+          <div class="bcl-sidebar col-lg-3">{{ _sidebar_rendered }}</div>
+          <div class="col-lg-9 col-xxl-8">{{ _content_rendered }}</div>
         {% endif %}
       </div>
     {% elseif _landing %}

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -34,6 +34,24 @@
 {% set _content_type = content_type|default('') %}
 {% set _classes = ['bcl-node-type'] %}
 
+{% set _content_rendered %}
+  {% block content_top %}
+    {{ content_top }}
+  {% endblock %}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+  {% block content_bottom %}
+    {{ content_bottom }}
+  {% endblock %}
+  {% block related %}
+    {{ related }}
+  {% endblock %}
+  {% block share %}
+    {{ share }}
+  {% endblock %}
+{% endset %}
+
 {% if _with_sidebar %}
   {% set _col_classes = {
     left: [
@@ -102,29 +120,17 @@
           {% block sidebar %}{% endblock %}
         </div>
         <div class="{{ _col_classes.right|join(' ') }}">
+          {{ _content_rendered }}
+        </div>
+      {% elseif _landing %}
+        <div class="col-12">
+          {{ _content_rendered }}
+        </div>
       {% else %}
-        {% if _landing %}
-          <div class="col-12">
-        {% else %}
-          <div class="col-12 col-lg-10 col-xl-9 col-xxl-8">
-        {% endif %}
+        <div class="col-12 col-lg-10 col-xl-9 col-xxl-8">
+          {{ _content_rendered }}
+        </div>
       {% endif %}
-      {% block content_top %}
-        {{ content_top }}
-      {% endblock %}
-      {% block content %}
-        {{ content }}
-      {% endblock %}
-      {% block content_bottom %}
-        {{ content_bottom }}
-      {% endblock %}
-      {% block related %}
-        {{ related }}
-      {% endblock %}
-      {% block share %}
-        {{ share }}
-      {% endblock %}
-      </div>
     </div>
   </div>
 </main>

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -112,24 +112,31 @@
 
   <div class="container mt-md-4-75 mt-4">
     {% block content_row %}{% endblock %}
-    <div class="row">
-      {% if _with_sidebar %}
+    {% if _with_sidebar %}
+      <div class="row">
         <div class="{{ _col_classes.left|join(' ') }}">
           {% block sidebar %}{% endblock %}
         </div>
         <div class="{{ _col_classes.right|join(' ') }}">
           {{ _content_rendered }}
         </div>
-      {% elseif _landing %}
-        <div class="col-12">
-          {{ _content_rendered }}
-        </div>
-      {% else %}
+      </div>
+    {% elseif _landing %}
+      {# No wrappers needed. #}
+      {{ _content_rendered }}
+    {% else %}
+      {#
+      Constrain the content width.
+      Use 'd-block' to neutralize the 'display: flex' from 'row' class.
+      This allows margins from content elements to collapse with margins
+      from other elements above or below.
+      #}
+      <div class="row d-block">
         <div class="col-12 col-lg-10 col-xl-9 col-xxl-8">
           {{ _content_rendered }}
         </div>
-      {% endif %}
-    </div>
+      </div>
+    {% endif %}
   </div>
 </main>
 

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -90,10 +90,10 @@
       {% set _sidebar_rendered %}{% block sidebar %}{% endblock %}{% endset %}
       <div class="row">
         {% if _sidebar_size == 'large' %}
-          <div class="bcl-sidebar col-lg-4">{{ _sidebar_rendered }}</div>
+          <aside class="bcl-sidebar col-lg-4">{{ _sidebar_rendered }}</aside>
           <div class="col-lg-8">{{ _content_rendered }}</div>
         {% else %}
-          <div class="bcl-sidebar col-lg-3">{{ _sidebar_rendered }}</div>
+          <aside class="bcl-sidebar col-lg-3">{{ _sidebar_rendered }}</aside>
           <div class="col-lg-9 col-xxl-8">{{ _content_rendered }}</div>
         {% endif %}
       </div>

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -124,6 +124,7 @@
       {% block share %}
         {{ share }}
       {% endblock %}
+      </div>
     </div>
   </div>
 </main>

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -88,7 +88,7 @@
     {% block content_row %}{% endblock %}
     {% if _with_sidebar %}
       {% set _sidebar_rendered %}{% block sidebar %}{% endblock %}{% endset %}
-      <div class="row">
+      <div class="row gy-5 children-eat-margins">
         {% if _sidebar_size == 'large' %}
           <aside class="bcl-sidebar col-lg-4">{{ _sidebar_rendered }}</aside>
           <div class="col-lg-8">{{ _content_rendered }}</div>

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -73,42 +73,42 @@
 {% endif %}
 
 <main {{ attributes }}>
-{% if messages is defined and messages is not empty %}
-  {% block messages_area %}
-  <div class="container">
-    {% for message in messages %}
-    {% set message_attributes = create_attribute().addClass(['mt-lg-5', 'mt-2']) %}
-      {% include '@oe-bcl/bcl-alert/alert.html.twig' with message|merge({
-        attributes: message_attributes,
-      }) only %}
-    {% endfor %}
-  </div>
-  {% endblock %}
-{% endif %}
+  {% if messages is defined and messages is not empty %}
+    {% block messages_area %}
+      <div class="container">
+        {% for message in messages %}
+          {% set message_attributes = create_attribute().addClass(['mt-lg-5', 'mt-2']) %}
+          {% include '@oe-bcl/bcl-alert/alert.html.twig' with message|merge({
+            attributes: message_attributes,
+          }) only %}
+        {% endfor %}
+      </div>
+    {% endblock %}
+  {% endif %}
 
-{% if _with_banner %}
-  {% block banner %}
-    {% include '@oe-bcl/bcl-content-banner/content-banner.html.twig' with banner only %}
-  {% endblock %}
-{% endif %}
+  {% if _with_banner %}
+    {% block banner %}
+      {% include '@oe-bcl/bcl-content-banner/content-banner.html.twig' with banner only %}
+    {% endblock %}
+  {% endif %}
 
   <div class="container mt-md-4-75 mt-4">
     <div class="row">
       {% block content_row %}
         {{ content_row }}
       {% endblock %}
-    {% if _with_sidebar %}
-      <div class="{{ _col_classes.left|join(' ') }}">
-        {% block sidebar %}{% endblock %}
-      </div>
-      <div class="{{ _col_classes.right|join(' ') }}">
-    {% else %}
-      {% if _landing %}
-      <div class="col-12">
+      {% if _with_sidebar %}
+        <div class="{{ _col_classes.left|join(' ') }}">
+          {% block sidebar %}{% endblock %}
+        </div>
+        <div class="{{ _col_classes.right|join(' ') }}">
       {% else %}
-      <div class="col-12 col-lg-10 col-xl-9 col-xxl-8">
+        {% if _landing %}
+          <div class="col-12">
+        {% else %}
+          <div class="col-12 col-lg-10 col-xl-9 col-xxl-8">
+        {% endif %}
       {% endif %}
-    {% endif %}
       {% block content_top %}
         {{ content_top }}
       {% endblock %}

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -111,9 +111,7 @@
   {% endif %}
 
   <div class="container mt-md-4-75 mt-4">
-    {% block content_row %}
-      {{ content_row }}
-    {% endblock %}
+    {% block content_row %}{% endblock %}
     <div class="row">
       {% if _with_sidebar %}
         <div class="{{ _col_classes.left|join(' ') }}">

--- a/src/compositions/bcl-base-templates/content-type.html.twig
+++ b/src/compositions/bcl-base-templates/content-type.html.twig
@@ -111,10 +111,10 @@
   {% endif %}
 
   <div class="container mt-md-4-75 mt-4">
+    {% block content_row %}
+      {{ content_row }}
+    {% endblock %}
     <div class="row">
-      {% block content_row %}
-        {{ content_row }}
-      {% endblock %}
       {% if _with_sidebar %}
         <div class="{{ _col_classes.left|join(' ') }}">
           {% block sidebar %}{% endblock %}

--- a/src/compositions/bcl-event/event.html.twig
+++ b/src/compositions/bcl-event/event.html.twig
@@ -5,20 +5,26 @@
 {% endblock %}
 
 {% block content %}
-  {% include '@oe-bcl/bcl-description-list/description-list.html.twig' with details_list only %}
+  <section class="mb-5">
+    {% include '@oe-bcl/bcl-description-list/description-list.html.twig' with details_list only %}
+  </section>
 
-  <h2 id="item-1" class="my-4">Description</h2>
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper,
-  a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet. Curabitur a efficitur ante. Phasellus non felis laoreet,
-  posuere ante ut, rhoncus tortor. Proin sed erat vel nisl luctus vulputate. Nunc tristique ultricies turpis, eu dictum enim ultrices vel.
-  Sed posuere at leo sit amet placerat. Sed dapibus viverra urna ac pretium. Praesent et laoreet erat, eget volutpat metus. Duis ac augue
-  sed tortor elementum dignissim in sit amet velit. Nullam nec viverra mi.
-  </p>
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper,
-  a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet.
-  </p>
+  <section class="mb-5">
+    <h2 id="item-1" class="my-4">Description</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper,
+    a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet. Curabitur a efficitur ante. Phasellus non felis laoreet,
+    posuere ante ut, rhoncus tortor. Proin sed erat vel nisl luctus vulputate. Nunc tristique ultricies turpis, eu dictum enim ultrices vel.
+    Sed posuere at leo sit amet placerat. Sed dapibus viverra urna ac pretium. Praesent et laoreet erat, eget volutpat metus. Duis ac augue
+    sed tortor elementum dignissim in sit amet velit. Nullam nec viverra mi.
+    </p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper,
+    a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet.
+    </p>
+  </section>
 
-  <h2 id="item-2" class="my-4">Related documents</h2>
-  {% include '@oe-bcl/bcl-file/file.html.twig' with files[0] only %}
-  {% include '@oe-bcl/bcl-file/file.html.twig' with files[1] only %}
+  <section class="mb-5">
+    <h2 id="item-2" class="my-4">Related documents</h2>
+    {% include '@oe-bcl/bcl-file/file.html.twig' with files[0] only %}
+    {% include '@oe-bcl/bcl-file/file.html.twig' with files[1] only %}
+  </section>
 {% endblock %}

--- a/src/compositions/bcl-glossary/glossary-listing.html.twig
+++ b/src/compositions/bcl-glossary/glossary-listing.html.twig
@@ -1,14 +1,16 @@
 {% extends '@oe-bcl/bcl-base-templates/listing-page.html.twig' %}
 
 {% block content_row %}
-  <div class="col-lg-4 col-md-6 col-12 mb-5">
-    {% include '@oe-bcl/bcl-search-form/search-form.html.twig' with search only %}
-  </div>
-  {% include '@oe-bcl/bcl-pagination/pagination.html.twig' with glossary only %}
-  <div class="col-12">
-    <div class="d-md-flex justify-content-end mb-md-5 align-items-center border-bottom-md border-top-md border-gray-300 py-5">
-      {% include '@oe-bcl/bcl-select/select.html.twig' with sortBy only %}
-      {% include '@oe-bcl/bcl-select/select.html.twig' with itemsPerPage only %}
+  <div class="row">
+    <div class="col-lg-4 col-md-6 col-12 mb-5">
+      {% include '@oe-bcl/bcl-search-form/search-form.html.twig' with search only %}
+    </div>
+    {% include '@oe-bcl/bcl-pagination/pagination.html.twig' with glossary only %}
+    <div class="col-12">
+      <div class="d-md-flex justify-content-end mb-md-5 align-items-center border-bottom-md border-top-md border-gray-300 py-5">
+        {% include '@oe-bcl/bcl-select/select.html.twig' with sortBy only %}
+        {% include '@oe-bcl/bcl-select/select.html.twig' with itemsPerPage only %}
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/src/compositions/bcl-glossary/glossary-listing.html.twig
+++ b/src/compositions/bcl-glossary/glossary-listing.html.twig
@@ -1,22 +1,21 @@
 {% extends '@oe-bcl/bcl-base-templates/listing-page.html.twig' %}
 
 {% block content_row %}
-	<div class="col-lg-4 col-md-6 col-12 mb-5">
-  	{% include '@oe-bcl/bcl-search-form/search-form.html.twig' with search only %}
+  <div class="col-lg-4 col-md-6 col-12 mb-5">
+    {% include '@oe-bcl/bcl-search-form/search-form.html.twig' with search only %}
   </div>
-		{% include '@oe-bcl/bcl-pagination/pagination.html.twig' with glossary only %}
-	<div class="col-12">
-	  <div class="d-md-flex justify-content-end mb-md-5 align-items-center border-bottom-md border-top-md border-gray-300 py-5">
-	    {% include '@oe-bcl/bcl-select/select.html.twig' with sortBy only %}
-	    {% include '@oe-bcl/bcl-select/select.html.twig' with itemsPerPage only %}
-	  </div>
+  {% include '@oe-bcl/bcl-pagination/pagination.html.twig' with glossary only %}
+  <div class="col-12">
+    <div class="d-md-flex justify-content-end mb-md-5 align-items-center border-bottom-md border-top-md border-gray-300 py-5">
+      {% include '@oe-bcl/bcl-select/select.html.twig' with sortBy only %}
+      {% include '@oe-bcl/bcl-select/select.html.twig' with itemsPerPage only %}
+    </div>
   </div>
 {% endblock %}
 
 {% block content_top %}
-	{% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-	  title: 'Starting with "A" (48)',
-	  title_tag: 'h2',
-	} only %}
-
+  {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+    title: 'Starting with "A" (48)',
+    title_tag: 'h2',
+  } only %}
 {% endblock %}

--- a/src/compositions/bcl-news/data/data--content.js
+++ b/src/compositions/bcl-news/data/data--content.js
@@ -7,6 +7,6 @@ module.exports = `<p id="content">Lorem ipsum dolor sit amet, consectetur adipis
       <li>${getDummyText(1, false)}</li>
       <li>${getDummyText(1, false)}</li>
     </ul>
-    <h2 class="my-4" id="subheading">Sub heading</h2>
+    <h2 id="subheading">Sub heading</h2>
     ${getDummyText(4, true)}
     ${getDummyText(6, true)}`;

--- a/src/compositions/bcl-news/data/data--content.js
+++ b/src/compositions/bcl-news/data/data--content.js
@@ -1,6 +1,7 @@
 const { getDummyText } = require("@openeuropa/bcl-data-utils");
 
-module.exports = `<p id="content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper, a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet. Curabitur a efficitur ante. Phasellus non felis laoreet, posuere ante ut, rhoncus tortor. Proin sed erat vel nisl luctus vulputate. Nunc tristique ultricies turpis, eu dictum enim ultrices vel. Sed posuere at leo sit amet placerat. Sed dapibus viverra urna ac pretium. Praesent et laoreet erat, eget volutpat metus. Duis ac augue sed tortor elementum dignissim in sit amet velit. Nullam nec viverra mi.</p>
+module.exports = `<div class="bcl-text">
+<p id="content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper, a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet. Curabitur a efficitur ante. Phasellus non felis laoreet, posuere ante ut, rhoncus tortor. Proin sed erat vel nisl luctus vulputate. Nunc tristique ultricies turpis, eu dictum enim ultrices vel. Sed posuere at leo sit amet placerat. Sed dapibus viverra urna ac pretium. Praesent et laoreet erat, eget volutpat metus. Duis ac augue sed tortor elementum dignissim in sit amet velit. Nullam nec viverra mi.</p>
     <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras facilisis enim non nisi hendrerit laoreet. Vestibulum id facilisis augue, vitae faucibus justo. Etiam congue malesuada urna vitae suscipit. Mauris a varius leo. Nulla vel facilisis lacus. Suspendisse semper velit sit amet purus egestas, sit amet ullamcorper enim egestas. Vestibulum at lacus at purus ornare auctor nec consequat velit. Pellentesque iaculis sit amet nulla at rutrum.</p>
     <ul>
       <li>${getDummyText(1, false)}</li>
@@ -9,4 +10,5 @@ module.exports = `<p id="content">Lorem ipsum dolor sit amet, consectetur adipis
     </ul>
     <h2 id="subheading">Sub heading</h2>
     ${getDummyText(4, true)}
-    ${getDummyText(6, true)}`;
+    ${getDummyText(6, true)}
+</div>`;

--- a/src/compositions/bcl-news/data/data--content2.js
+++ b/src/compositions/bcl-news/data/data--content2.js
@@ -1,0 +1,14 @@
+const { getDummyText } = require("@openeuropa/bcl-data-utils");
+
+module.exports = `<div class="bcl-text">
+<h3>Rich text top heading level 3</h3>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sit amet eleifend tortor. In facilisis eros vitae turpis ullamcorper, a euismod dolor lacinia. Nam facilisis ipsum et sollicitudin imperdiet. Curabitur a efficitur ante. Phasellus non felis laoreet, posuere ante ut, rhoncus tortor. Proin sed erat vel nisl luctus vulputate. Nunc tristique ultricies turpis, eu dictum enim ultrices vel. Sed posuere at leo sit amet placerat. Sed dapibus viverra urna ac pretium. Praesent et laoreet erat, eget volutpat metus. Duis ac augue sed tortor elementum dignissim in sit amet velit. Nullam nec viverra mi.</p>
+    <h2>Sub heading level two</h2>
+    ${getDummyText(4, true)}
+    <h3>Sub heading level three</h3>
+    ${getDummyText(1, true)}
+    <h4>Sub heading level four</h4>
+    ${getDummyText(1, true)}
+    <h5>Sub heading level five</h5>
+    ${getDummyText(1, true)}
+</div>`;

--- a/src/compositions/bcl-news/data/data.js
+++ b/src/compositions/bcl-news/data/data.js
@@ -13,6 +13,7 @@ import isChromatic from "chromatic/isChromatic";
 
 import dataListing from "@openeuropa/bcl-news/data/data--listing";
 import content from "@openeuropa/bcl-news/data/data--content";
+import content2 from "@openeuropa/bcl-news/data/data--content2";
 
 const chromatic = process.env.STORYBOOK_ENV;
 
@@ -44,6 +45,13 @@ const demoData = {
   share,
 };
 
+const demoData2 = {
+  ...baseData,
+  banner,
+  content: content2,
+  share,
+};
+
 const demoListing = {
   ...baseData,
   ...dataListing,
@@ -59,4 +67,4 @@ const demoListing = {
   },
 };
 
-export { demoData, demoListing };
+export { demoData, demoData2, demoListing };

--- a/src/compositions/bcl-news/news.story.js
+++ b/src/compositions/bcl-news/news.story.js
@@ -1,7 +1,7 @@
 import { withDesign } from "storybook-addon-designs";
 import { initBadges, correctPaths } from "@openeuropa/bcl-story-utils";
 
-import { demoData, demoListing } from "@openeuropa/bcl-news/data/data";
+import { demoData, demoData2, demoListing } from "@openeuropa/bcl-news/data/data";
 import listingPage from "@openeuropa/bcl-base-templates/listing-page.html.twig";
 import news from "@openeuropa/bcl-base-templates/content-type.html.twig";
 
@@ -21,6 +21,24 @@ export const FullPage = () => news(correctPaths(demoData));
 
 FullPage.storyName = "News page";
 FullPage.parameters = {
+  design: [
+    {
+      name: "Mockup - Desktop",
+      type: "figma",
+      url: "https://www.figma.com/file/NQlGvTiTXZYN8TwY2Ur5EI/BCL-Features?node-id=10377%3A243152",
+    },
+    {
+      name: "Mockup - Mobile",
+      type: "figma",
+      url: "https://www.figma.com/file/NQlGvTiTXZYN8TwY2Ur5EI/BCL-Features?node-id=10377%3A243122",
+    },
+  ],
+};
+
+export const FullPage2 = () => news(correctPaths(demoData2));
+
+FullPage2.storyName = "News page 2";
+FullPage2.parameters = {
   design: [
     {
       name: "Mockup - Desktop",

--- a/src/compositions/bcl-project/data/data--lists.js
+++ b/src/compositions/bcl-project/data/data--lists.js
@@ -1,4 +1,3 @@
-const drupalAttribute = require("drupal-attribute");
 const { getDummyText } = require("@openeuropa/bcl-data-utils");
 
 module.exports = {
@@ -91,7 +90,7 @@ module.exports = {
   },
   content_lists: {
     title: "Contributors",
-    title_attributes: new drupalAttribute().setAttribute("id", "contributors"),
+    id: "contributors",
     items: [
       {
         content: [

--- a/src/compositions/bcl-project/project-lists.html.twig
+++ b/src/compositions/bcl-project/project-lists.html.twig
@@ -26,45 +26,42 @@
 {% set _title_classes = ['my-4-5'] %}
 {% set _title_attributes = _title_attributes.addClass(_title_classes) %}
 
-<div
-  {{ attributes }}
->
-{% if _title is not empty %}
-  {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-    title: _title,
-    title_tag: _title_tag,
-    title_link: _title_link,
-    attributes: _title_attributes,
-  } only %}
-{% endif %}
-{% if _items is defined and _items is not empty %}
-  {% for _item in _items %}
-    {% if _item.title is not empty %}
-      {% set _item_title_attributes = _item.title_attributes ?: create_attribute() %}
-      {% set _item_title_attributes = _item_title_attributes.addClass(['mb-3']) %}
-      {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-        title: _item.title,
-        title_tag: _item.title_tag|default('h3'),
-        title_link: _item.title_link|default({}),
-        attributes: _item_title_attributes,
-      } only %}
-    {% endif %}
-    {% for _list in _item.content %}
-      {% if _list.attributes is empty %}
-        {% set _list = _list|merge({
-          attributes: create_attribute()
-        }) %}
+<div {{ attributes }}>
+  {% if _title is not empty %}
+    {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+      title: _title,
+      title_tag: _title_tag,
+      title_link: _title_link,
+      attributes: _title_attributes,
+    } only %}
+  {% endif %}
+  {% if _items is defined and _items is not empty %}
+    {% for _item in _items %}
+      {% if _item.title is not empty %}
+        {% set _item_title_attributes = _item.title_attributes ?: create_attribute() %}
+        {% set _item_title_attributes = _item_title_attributes.addClass(['mb-3']) %}
+        {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+          title: _item.title,
+          title_tag: _item.title_tag|default('h3'),
+          title_link: _item.title_link|default({}),
+          attributes: _item_title_attributes,
+        } only %}
       {% endif %}
-      {% if not loop.last %}
-        {% set _list = _list|merge({
+      {% for _list in _item.content %}
+        {% if _list.attributes is empty %}
+          {% set _list = _list|merge({
+            attributes: create_attribute()
+          }) %}
+        {% endif %}
+        {% if not loop.last %}
+          {% set _list = _list|merge({
             attributes: _list.attributes.addClass(['border-bottom', 'mb-3'])
-          })
-        %}
-      {% endif %}
-      {% include '@oe-bcl/bcl-description-list/description-list.html.twig' with _list only %}
+          }) %}
+        {% endif %}
+        {% include '@oe-bcl/bcl-description-list/description-list.html.twig' with _list only %}
+      {% endfor %}
     {% endfor %}
-  {% endfor %}
-{% endif %}
+  {% endif %}
 </div>
 
 {% endspaceless %}

--- a/src/compositions/bcl-project/project-lists.html.twig
+++ b/src/compositions/bcl-project/project-lists.html.twig
@@ -14,6 +14,7 @@
 #}
 
 {% set _title = title|default('') %}
+{% set _id = id|default(null) %}
 {% set _title_tag = title_tag|default('h2') %}
 {% set _title_link = title_link|default({}) %}
 {% set _title_attributes = title_attributes ?: create_attribute() %}
@@ -26,15 +27,7 @@
 {% set _title_classes = ['my-4-5'] %}
 {% set _title_attributes = _title_attributes.addClass(_title_classes) %}
 
-<div {{ attributes }}>
-  {% if _title is not empty %}
-    {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-      title: _title,
-      title_tag: _title_tag,
-      title_link: _title_link,
-      attributes: _title_attributes,
-    } only %}
-  {% endif %}
+{% set _rendered_content %}
   {% if _items is defined and _items is not empty %}
     {% for _item in _items %}
       {% if _item.title is not empty %}
@@ -62,6 +55,12 @@
       {% endfor %}
     {% endfor %}
   {% endif %}
-</div>
+{% endset %}
+
+{% include '@oe-bcl/bcl-section/section.html.twig' with {
+  title: _title,
+  id: _id,
+  content: _rendered_content,
+} only %}
 
 {% endspaceless %}

--- a/src/compositions/bcl-project/project.html.twig
+++ b/src/compositions/bcl-project/project.html.twig
@@ -5,37 +5,30 @@
 {% endblock %}
 
 {% block content %}
-  {% if project_status_title is not empty %}
-    {% set _project_title_attributes = create_attribute().addClass(['mb-4']) %}
-    {% if project_status_id is not empty %}
-      {% set _project_title_attributes = _project_title_attributes.setAttribute('id', project_status_id) %}
+  {% set _project_status_rendered %}
+    {% if project_status is not empty %}
+      {% include '@oe-bcl/bcl-project-status/project-status.html.twig' with project_status %}
     {% endif %}
-    {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-      title: project_status_title,
-      title_tag: 'h2',
-      attributes: _project_title_attributes,
-    } only %}
-  {% endif %}
-  {% if project_status is not empty %}
-    {% include '@oe-bcl/bcl-project-status/project-status.html.twig' with project_status %}
-  {% endif %}
-  {% if project_contributions is not empty %}
-    {% include '@oe-bcl/bcl-project-status/project-contributions.html.twig' with project_contributions %}
-  {% endif %}
-
-  {% if status_lists is not empty %}
-    {% include '@oe-bcl/bcl-project/project-lists.html.twig' with status_lists only %}
-  {% endif %}
+    {% if project_contributions is not empty %}
+      {% include '@oe-bcl/bcl-project-status/project-contributions.html.twig' with project_contributions %}
+    {% endif %}
+    {% if status_lists is not empty %}
+      {% include '@oe-bcl/bcl-project/project-lists.html.twig' with status_lists only %}
+    {% endif %}
+  {% endset %}
+  {% include '@oe-bcl/bcl-section/section.html.twig' with {
+    title: project_status_title,
+    id: project_status_id,
+    content: _project_status_rendered,
+  } only %}
 
   {% if first_paragraphs is defined and first_paragraphs is not empty %}
     {% for _paragraph in first_paragraphs %}
-      {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+      {% include '@oe-bcl/bcl-section/section.html.twig' with {
         title: _paragraph.title,
-        title_tag: 'h2',
-        attributes: create_attribute().addClass(['mb-4', 'pt-3'])
-                                      .setAttribute('id', _paragraph.title_id),
+        id: _paragraph.title_id,
+        content: _paragraph.content,
       } only %}
-      {{- _paragraph.content -}}
     {% endfor %}
   {% endif %}
 
@@ -49,31 +42,23 @@
 
   {% if second_paragraphs is defined and second_paragraphs is not empty %}
     {% for _paragraph in second_paragraphs %}
-      {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+      {% include '@oe-bcl/bcl-section/section.html.twig' with {
         title: _paragraph.title,
-        title_tag: 'h2',
-        attributes: create_attribute().addClass(['mb-4', 'pt-3'])
-                                      .setAttribute('id', _paragraph.title_id),
+        id: _paragraph.title_id,
+        content: _paragraph.content,
       } only %}
-      {{- _paragraph.content -}}
     {% endfor %}
   {% endif %}
 
-  {% if gallery.main_title is not empty %}
-    {% set _gallery_title_attributes = create_attribute().addClass(['my-4']) %}
-    {% if gallery.main_title_id is not empty %}
-      {% set _gallery_title_attributes = _gallery_title_attributes.setAttribute('id', gallery.main_title_id) %}
-    {% endif %}
-    {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-      title: gallery.main_title,
-      title_tag: 'h2',
-      attributes: _gallery_title_attributes,
-    } only %}
-  {% endif %}
   {% if gallery is not empty %}
-  <div class="mt-3 mb-4-5">
-    {% include '@oe-bcl/bcl-gallery/gallery.html.twig' with gallery only %}
-  </div>
+    {% set _gallery_rendered %}
+      {% include '@oe-bcl/bcl-gallery/gallery.html.twig' with gallery only %}
+    {% endset %}
+    {% include '@oe-bcl/bcl-section/section.html.twig' with {
+      title: gallery.main_title,
+      id: gallery.main_title_id,
+      content: _gallery_rendered,
+    } only %}
   {% endif %}
 
   {% if social_block is not empty %}

--- a/src/compositions/bcl-publication/publication.html.twig
+++ b/src/compositions/bcl-publication/publication.html.twig
@@ -7,7 +7,7 @@
 {% block content %}
   {% if authors is defined and authors is not empty %}
     <h2
-      class="mb-2-5"
+      class="mb-2-5 mt-5"
       id="{{ authors.title_id }}"
     >
       {{- authors.title -}}
@@ -25,7 +25,7 @@
 
   {% if description is defined and description is not empty %}
     <h2
-      class="mb-4 pt-2-5"
+      class="mb-4 mt-5"
       id="{{ description.title_id }}"
     >
       {{- description.title -}}
@@ -36,7 +36,7 @@
   {% endif %}
 
   {% if file is not empty %}
-    <div class="pt-2 mb-4">
+    <div class="mb-4 mt-5">
       {% include '@oe-bcl/bcl-file/file.html.twig' with file only %}
     </div>
   {% endif %}

--- a/src/compositions/bcl-publication/publication.html.twig
+++ b/src/compositions/bcl-publication/publication.html.twig
@@ -31,7 +31,7 @@
       {{- description.title -}}
     </h2>
     {% for paragraph in description.paragraphs %}
-      <p class="mb-3">{{- paragraph -}}</p>
+      <p>{{- paragraph -}}</p>
     {% endfor %}
   {% endif %}
 

--- a/src/compositions/bcl-vacancy/data/data--details.js
+++ b/src/compositions/bcl-vacancy/data/data--details.js
@@ -20,9 +20,9 @@ module.exports = {
     content: getDummyText(3, true),
     action_bar: `<div class="d-grid d-md-block mt-3-5"><button class="btn btn-primary btn-md" type="button"><svg class="me-2-5 bi icon--fluid"><use xlink:href="/icons.svg#pencil-fill"></use></svg>Apply now</button></div>`,
   },
+  files_title: "File download",
   files: [
     {
-      title: "File download",
       item_title: "File title",
       language: "English",
       meta: "(16.2 MB - PDF)",

--- a/src/compositions/bcl-vacancy/vacancy.html.twig
+++ b/src/compositions/bcl-vacancy/vacancy.html.twig
@@ -19,36 +19,44 @@
 
 {% block content %}
   {% if description is defined and description is not empty %}
-    <h2
-      class="mb-4"
-      id="{{ description.title_id }}"
-    >
-      {{- description.title -}}
-    </h2>
-    {% for paragraph in description.paragraphs %}
-      <p>{{- paragraph -}}</p>
-    {% endfor %}
+    {% set _description_rendered %}
+      {% for paragraph in description.paragraphs %}
+        <p>{{- paragraph -}}</p>
+      {% endfor %}
+    {% endset %}
+    {% include '@oe-bcl/bcl-section/section.html.twig' with {
+      title: description.title,
+      id: description.title_id,
+      content: _description_rendered,
+    } only %}
   {% endif %}
 
   {% if files is not empty %}
-    {% for file in files %}
-      <div class="pt-4">
-        {% include '@oe-bcl/bcl-file/file.html.twig' with file only %}
-      </div>
-    {% endfor %}
+    {% set _files_rendered %}
+      {% for file in files %}
+        <div class="mb-4">
+          {% include '@oe-bcl/bcl-file/file.html.twig' with file only %}
+        </div>
+      {% endfor %}
+    {% endset %}
+    {% include '@oe-bcl/bcl-section/section.html.twig' with {
+      title: files_title,
+      content: _files_rendered,
+    } only %}
   {% endif %}
 
   {% if social_block is not empty %}
     {% block social_block %}
-      <h2
-        class="mb-4 pt-4"
-        id="{{ social.title_id }}"
-      >
-        {{- social.title -}}
-      </h2>
-      {{ social_buttons }}
-      {% include '@oe-bcl/bcl-button/button.html.twig' with button_social_modal only %}
-      {% include '@oe-bcl/bcl-modal/modal.html.twig' with social_modal only %}
+      {% set _social_rendered %}
+        {{ social_buttons }}
+        {% include '@oe-bcl/bcl-button/button.html.twig' with button_social_modal only %}
+        {% include '@oe-bcl/bcl-modal/modal.html.twig' with social_modal only %}
+      {% endset %}
+      {% include '@oe-bcl/bcl-section/section.html.twig' with {
+        title: social.title,
+        id: social.title_id,
+        content: _social_rendered,
+      } only %}
     {% endblock %}
   {% endif %}
 {% endblock %}

--- a/src/compositions/bcl-vacancy/vacancy.html.twig
+++ b/src/compositions/bcl-vacancy/vacancy.html.twig
@@ -26,7 +26,7 @@
       {{- description.title -}}
     </h2>
     {% for paragraph in description.paragraphs %}
-      <p class="mb-3">{{- paragraph -}}</p>
+      <p>{{- paragraph -}}</p>
     {% endfor %}
   {% endif %}
 

--- a/src/themes/default/src/scss/_bcl-text.scss
+++ b/src/themes/default/src/scss/_bcl-text.scss
@@ -1,0 +1,32 @@
+/**
+ * Wrapper for rich text styles.
+ *
+ * Bootstrap 5 follows a single-direction strategy for vertical margins.
+ * Elements only have a margin-bottom, never a margin-top.
+ * See https://getbootstrap.com/docs/5.0/content/reboot/#approach.
+ * Also https://csswizardry.com/2012/06/single-direction-margin-declarations/.
+ *
+ * Unfortunately, with this approach we cannot have extra vertical space above
+ * e.g. h2 tags, to set a distance to previous content, if the margin-bottom of
+ * that previous content is not sufficient. We want to add margin-top to at
+ * least some headings.
+ *
+ * In headings defined in templates, this can be achieved with 'mt-*' utility
+ * classes.
+ *
+ * In rich text, the margin-top will be added to all h* headings, based on a
+ * '.bcl-text' wrapper. This is also what Bootstrap itself does in its doc
+ * pages: Inspect the h2 headings in the doc page linked above!
+ *
+ * No special exception for :first-child is added, this will be compensated with
+ * the 'eat-margin-*' classes instead.
+ */
+.bcl-text h1,
+.bcl-text h2,
+.bcl-text h3,
+.bcl-text h4,
+.bcl-text h5,
+.bcl-text h6 {
+  /* Use em units to scale with the font size. */
+  margin-top: 1em;
+}

--- a/src/themes/default/src/scss/mixins/_eat-margins.scss
+++ b/src/themes/default/src/scss/mixins/_eat-margins.scss
@@ -1,0 +1,32 @@
+
+// Local helper mixin. Don't use elsewhere.
+@mixin eat-margins-pseudo-element($appetite) {
+  content: '';
+  height: 0;
+  display: flex;
+  visibility: hidden;
+  margin-top: -$appetite;
+  margin-bottom: $appetite;
+}
+
+// Neutralizes bottom margin of last child element.
+@mixin eat-margin-top($appetite: 200px) {
+  &::before {
+    @include eat-margins-pseudo-element($appetite);
+  }
+}
+
+// Neutralizes the top margin of first child element.
+@mixin eat-margin-bottom($appetite: 200px) {
+  &::after {
+    @include eat-margins-pseudo-element(-$appetite);
+  }
+}
+
+// Neutralizes margins of child elements:
+// - top margin of first element or its first children.
+// - bottom margin of last element or its last children.
+@mixin eat-margins($appetite_top: 200px, $appetite_bottom: $appetite_top) {
+  @include eat-margin-top($appetite_top);
+  @include eat-margin-bottom($appetite_bottom);
+}

--- a/src/themes/default/src/scss/oe-bcl-default.scss
+++ b/src/themes/default/src/scss/oe-bcl-default.scss
@@ -62,6 +62,7 @@
 
 // Custom styles
 @import "@openeuropa/bcl-theme-default/src/scss/alert";
+@import "@openeuropa/bcl-theme-default/src/scss/bcl-text";
 @import "@openeuropa/bcl-theme-default/src/scss/button";
 @import "@openeuropa/bcl-theme-default/src/scss/card";
 @import "@openeuropa/bcl-theme-default/src/scss/collapse";

--- a/src/themes/default/src/scss/oe-bcl-default.scss
+++ b/src/themes/default/src/scss/oe-bcl-default.scss
@@ -55,6 +55,10 @@
 
 // BCL mixins
 @import "@openeuropa/bcl-theme-default/src/scss/base/mixins";
+@import "@openeuropa/bcl-theme-default/src/scss/mixins/eat-margins";
+
+// BCL utilities
+@import "@openeuropa/bcl-theme-default/src/scss/utilities/eat-margins";
 
 // Custom styles
 @import "@openeuropa/bcl-theme-default/src/scss/alert";

--- a/src/themes/default/src/scss/utilities/_eat-margins.scss
+++ b/src/themes/default/src/scss/utilities/_eat-margins.scss
@@ -1,0 +1,23 @@
+// Utility classes to absorb/neutralize vertical margins of child elements.
+// This allows to fully control vertical space using padding, without additional
+// space caused by margins of e.g. <h2> or <p> elements inside the container.
+// This is more reliably than anything with :first-child or :last-child, because
+// it considers only visible block-level elements.
+
+// Neutralizes top margin of first child, and bottom margin of last child.
+.eat-margins,
+.children-eat-margins > * {
+  @include eat-margins();
+}
+
+// Neutralizes top margin of the first block-level child element.
+.eat-margin-top,
+.children-eat-margin-top > * {
+  @include eat-margin-top();
+}
+
+// Neutralizes bottom margin of the last block-level child element.
+.eat-margin-bottom,
+.children-eat-margin-bottom > * {
+  @include eat-margin-bottom();
+}


### PR DESCRIPTION
Proof-of-concept solution for vertical margins.

## Goals
- Standardize vertical margins between elements.
- Use margins for vertical space _between_ elements, avoid padding where margin would be the more natural fit.
- Stick with Bootstrap strategies as much as possible.
- Stick with utility classes.
- Avoid classes that must be applied conditionally depending on outside criteria (e.g. whether specific other element exists).
  - -> Make vertical spacing still work correctly if some elements on the page are missing or empty.
- Avoid element classes in rich text. (E.g. `<p>` tags typically come from rich text, and the editor won't be allowed to add classes.)
- Avoid unnecessary wrappers.
- Avoid custom contextual CSS that expects a specific DOM structure.
- Semantic html where it makes sense - e.g. wrapping sections into `<section>` seems like a good idea.

## Strategy
- Step 1:
  - Use margin-bottom over margin-top, see https://getbootstrap.com/docs/5.0/content/reboot/#approach and https://csswizardry.com/2012/06/single-direction-margin-declarations/.
  - Clean up one-off paddings and margins and replace them with standardized margins.
  - Wrap main content sections into `<section class="mb-5">`, with `<h2>` title.
    - I chose `.mb-5`, but we could choose a smaller margin.
- Step 2:
  - Introduce `.eat-margin*` utility classes that can absorb margins of first and last element more reliably than `:first-child` or `:last-child` rules.
  - Add `.children-eat-margin` class to `.row` elements, to neutralize margins in column elements.
  - Add `gy-5` class for vertical margin between columns in mobile viewport.
  - Add `.bcl-text` class as a wrapper for rich text, and set margin-top for h* headings within these rich text blocks. Use `.eat-margin` or `eat-margin-top` to neutralize the margin-top of the first element, _or_ allow margin collapse with the margin-top of the parent element.
  - Add `margin-top` to other elements as needed, now that we can absorb it with `eat-margin`.
- Step 3:
  - We _could_ go fully to symmetric margins (top and bottom), now that we have the `eat-margin` utilities. But let's first see how far we get with one-directional margins.

## Scope
- Only applied to some content type pages for proof-of-concept.
- Some pages show alternative solutions. E.g. for publication I add `mt-5` to h2 headings instead of wrapping the sections.
- I did not bother with tests for now. I would have to study how they work, out of scope for me.

I have more changes locally, but I want to limit the scope for now.

## Comparison to other PR
There was an alternative PR #363 by @planctus, with a similar goal. So what are the similarities and differences?

|                                    | This PR (#429)                                                                                                                                                  | Other PR (#363)                                                                                                                                                                                                         |
|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| section concept                    | introduces "sections". One level of `<section>` tags                                                                                                            | introduces "sections" concept. Two levels: bcl-section, bcl-section-group                                                                                                                                               |
| classes and css for margins        | uses existing bootstrap utility classes for margins                                                                                                             | introduces new bcl-section and bcl-section-group classes for margins                                                                                                                                                    |
| disable margin of first/last child | new `eat-margin` utility classes to control first and last element margin. Direct child selector (`>`) prevents undesired side effect on nested child elements. | contextual CSS with `:first-parent`, `:last-parent` and similar to control first and last element margin. Direct child selector (`>`) used for some rules, but not all -> side effects on nested children are possible. |
| margin-top or margin-bottom?       | margin-bottom as starting point, following common approach from bootstrap 5.                                                                                    | margin-top for section elements                                                                                                                                                                                         |
| local or global?                   | solution can be applied locally and piecemeal                                                                                                                   | solution should be applied to a larger part of the page for the desired outcome. E.g. we also have to add the classes in the sidebar.                                                                                   |
| strategy or solution?              | overall more like a "strategy" for how to apply existing solutions, rather than a completely new solution.                                                      | new solution to replace existing classes.                                                                                                                                                                               |

## TBD
- What's the best way to apply the `<section ..>` wrapper? I made an include file, but it requires to capture the content first. Would be cool to have an alternative syntax using twig `{% apply ... %}{% endapply %}`.
- Do we want the `<section>` wrapper, or would we rather add `mt-5` to each `<h2>` that acts as a section title?
- Are we ok with the proposed margins? Or is `mt-5` too big?