### PR TITLE
refactor: OEL-3775: Negative extended spacers.

### DIFF
--- a/src/themes/default/src/scss/base/_variables.scss
+++ b/src/themes/default/src/scss/base/_variables.scss
@@ -1,6 +1,3 @@
-$enable-negative-margins: true;
-$negative-spacers: negativify-map($spacers);
-
 // Colors variables
 $lighter: $gray-100;
 $date: #1698af;
@@ -67,6 +64,8 @@ $spacers-extended: (
 
 $spacers: map-merge($spacers, $spacers-extended);
 $gutters: $spacers;
+$enable-negative-margins: true;
+$negative-spacers: negativify-map($spacers);
 
 // accordion
 $accordion-button-active-color: $accordion-button-color;


### PR DESCRIPTION
At this moment it exists negative bootstrap classes :

`.mt-n4` for a margin top negative of value 4 (which is "2 rem" in CSS value)
It exists` .mt-4-75` but not `.mt-n4-75`